### PR TITLE
Merge Develop. Version bumped from (2, 2, 2) to (2, 2, 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+**__pycache__/
+data/
+tags/
+**.cfg
+**.log
+**.backup
+**.BACKUP

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-**__pycache__/
+__pycache__/
 data/
 tags/
-**.cfg
-**.log
-**.backup
-**.BACKUP
+*.cfg
+*.log
+*.backup
+*.BACKUP

--- a/.hgignore
+++ b/.hgignore
@@ -1,8 +1,0 @@
-syntax: glob
-*__pycache__/*
-data/*
-tags/*
-*.cfg
-*.log
-*.backup
-*.BACKUP

--- a/__init__.py
+++ b/__init__.py
@@ -3,8 +3,8 @@
 # ##############
 __author__ = "Devin Bobadilla"
 #           YYYY.MM.DD
-__date__ = "2019.08.15"
-__version__ = (2, 2, 2)
+__date__ = "2019.09.05"
+__version__ = (2, 2, 3)
 __all__ = (
     'defs', 'heuristic_deprotection', 'repl', 'tag_index', 'widgets', 'windows',
     'constants', 'core', 'crc_functions', 'exceptions', 'main',

--- a/windows/meta_window.py
+++ b/windows/meta_window.py
@@ -3,6 +3,7 @@ import refinery
 import tkinter as tk
 
 from binilla import editor_constants as e_c
+from binilla import constants
 from binilla.windows.tag_window import TagWindow
 
 from mozzarilla.widgets.field_widget_picker import def_halo_widget_picker
@@ -73,7 +74,7 @@ class MetaWindow(TagWindow):
 
         try:
             if visibility_level == constants.VISIBILITY_METADATA:
-                return bool(self.app_root.show_structure_meta_fields.get())
+                return bool(self.app_root.show_structure_meta.get())
             elif visibility_level == constants.VISIBILITY_HIDDEN:
                 return bool(self.app_root.show_all_fields.get())
             else:

--- a/windows/settings_window.py
+++ b/windows/settings_window.py
@@ -130,7 +130,7 @@ class RefinerySettingsWindow(tk.Toplevel, BinillaWidget):
         
         self.dont_touch_frame = tk.LabelFrame(
             self.tag_fixup_frame,
-            text="ONLY UNCHECK THESE IF YOU ARE NOT DEALING WITH PROTECTED MAPS")
+            text="ONLY CHECK THESE IF YOU ARE NOT DEALING WITH PROTECTED MAPS")
         self.disable_safe_mode_cbtn = tk.Checkbutton(
             self.dont_touch_frame, variable=self.disable_safe_mode, justify="left",
             text="Disable safe-mode")

--- a/windows/settings_window.py
+++ b/windows/settings_window.py
@@ -130,7 +130,7 @@ class RefinerySettingsWindow(tk.Toplevel, BinillaWidget):
         
         self.dont_touch_frame = tk.LabelFrame(
             self.tag_fixup_frame,
-            text="ONLY CHECK THESE IF YOU ARE NOT DEALING WITH PROTECTED MAPS")
+            text="ONLY UNCHECK THESE IF YOU ARE NOT DEALING WITH PROTECTED MAPS")
         self.disable_safe_mode_cbtn = tk.Checkbutton(
             self.dont_touch_frame, variable=self.disable_safe_mode, justify="left",
             text="Disable safe-mode")


### PR DESCRIPTION
Fixed bug with MetaWindow not properly returning the visibility level of fields due to a missing import of binilla.constants, and incorrect property access.